### PR TITLE
Fix cacti return type error

### DIFF
--- a/cacti/powergating.cc
+++ b/cacti/powergating.cc
@@ -110,7 +110,7 @@ Sleep_tx::Sleep_tx(
 
 }
 
-double Sleep_tx::compute_penalty()
+void Sleep_tx::compute_penalty()
 {
 	//V_delta = VDD - VCCmin nothing to do with threshold of sleep tx. Although it might be OK to use sleep tx to control the V_delta
 	double c_load;

--- a/cacti/powergating.h
+++ b/cacti/powergating.h
@@ -73,7 +73,7 @@ public:
 
 
 //	void   compute_area();
-	double compute_penalty();  // return outrisetime
+	void compute_penalty();  // return outrisetime
 
 	void leakage_feedback(double temperature){};
 	~Sleep_tx(){};


### PR DESCRIPTION
The null return make McPAT can't process energy successfully.